### PR TITLE
詳細ページで、表示されているプロトタイプの投稿者名を表示

### DIFF
--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -4,7 +4,7 @@
       <p class="prototype__hedding">
         <%= @prototype.title%>
       </p>
-      <%= link_to "by プロトタイプの投稿者", root_path, class: :prototype__user %>
+      <%= link_to "by #{@prototype.user.name}", user_path(@prototype.user), class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
       <div class="prototype__manage">
         <% if user_signed_in? && current_user.id == @prototype.user_id %>


### PR DESCRIPTION
# What
プロトタイプの投稿者名を表示
# Why
プロトタイプを投稿したuser情報を伝えるため