### PR TITLE
comment内容のデータ型をstringからtextへ変更

### DIFF
--- a/db/migrate/20240419085602_change_data_content_to_comment.rb
+++ b/db/migrate/20240419085602_change_data_content_to_comment.rb
@@ -1,0 +1,5 @@
+class ChangeDataContentToComment < ActiveRecord::Migration[7.0]
+  def change
+    change_column :comments, :content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_18_110038) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_19_085602) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -21,7 +21,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_18_110038) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", charset: "utf8", force: :cascade do |t|
   create_table "active_storage_blobs", charset: "utf8", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
@@ -35,14 +34,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_18_110038) do
   end
 
   create_table "active_storage_variant_records", charset: "utf8", force: :cascade do |t|
-  create_table "active_storage_variant_records", charset: "utf8", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "comments", charset: "utf8", force: :cascade do |t|
-    t.string "content", null: false
+    t.text "content", null: false
     t.bigint "prototype_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -61,7 +59,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_18_110038) do
     t.index ["user_id"], name: "index_prototypes_on_user_id"
   end
 
-  create_table "users", charset: "utf8", force: :cascade do |t|
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.text "name", null: false
     t.text "profile", null: false


### PR DESCRIPTION
# What
カラムのtype変更
# Why
要件定義に合わせるため